### PR TITLE
fix loading rangy consistently

### DIFF
--- a/src/cursors.tsx
+++ b/src/cursors.tsx
@@ -32,4 +32,9 @@ document.documentElement.style.minHeight = "100dvh";
 // add a classname
 cursorsRoot.classList.add("cursors-root");
 
-render(<App />, cursorsRoot);
+// rangy has it's own weird module system, that
+// waits for the DOM to be ready before loading
+// so we need to wait for that before rendering our app
+document.addEventListener("DOMContentLoaded", () => {
+  render(<App />, cursorsRoot);
+});


### PR DESCRIPTION
Rangy, as was the fashion of the time, defines it's own module loading system. Of note about the way rangy does it, it waits for the website's `DOMContentLoaded` event to fire before initialising it's own modules (see: https://github.com/timdown/rangy/blob/8aea7eb14b31d9c7240ce539544bef9337a8b597/src/core/core.js#L499-L511). The assumption here is that your app would do that as well (like jquery's `$.ready(...)`, or just `$(...)`). However, modern browsers don't care about that anymore, and even our own code just runs when it's loaded by the script tag. As such, when we ran our code, sometimes (most times!) it would run before that event was fired, so it would run before rangy's modules were initialised, and it would fail to find any of the extensions defined on the `rangy` variable/namespace, like the `.getElementChecksum()` function (even though the `rangy` "global" was already defined). The fix here is to wait for the event before we render our react app. Annoying, because it delays our loading by a scooch, but it's fine. A better fix would be to rewrite rangy without all this module loading fluff, but eh.