### PR TITLE
Dashboard: realtime updates, onError reporting, daily reconciliation

### DIFF
--- a/docs/superpowers/plans/2026-04-17-dashboard-realtime-and-reconciliation.md
+++ b/docs/superpowers/plans/2026-04-17-dashboard-realtime-and-reconciliation.md
@@ -1,0 +1,601 @@
+# Dashboard Real-Time Updates, onError Reporting, and Daily Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the cursor-party dashboard update in real time, harden presence-server error paths, and add a daily reconciliation loop that prunes stale entries by querying each tracked PresenceAgent directly.
+
+**Architecture:** The singleton `DashboardServer` Durable Object keeps a `traffic` map. We change its value shape from `number` to `{ name, count }` so we can call `getAgentByName(PRESENCE_SERVER, name).getConnectionCount()` during reconciliation. Real-time push uses the Agents SDK's built-in WebSocket upgrade on `/dashboard` — `onConnect` sends the current state, and every state mutation triggers `this.broadcast()`. Daily reconciliation is scheduled in `onStart` via `scheduleEvery(86400, "reconcile")`, with the schedule id stored in state for idempotency.
+
+**Tech Stack:** TypeScript, Cloudflare Workers + Durable Objects, Cloudflare Agents SDK (`agents` package v0.11.1), esbuild.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-dashboard-realtime-and-reconciliation-design.md`
+
+**Testing note:** This repo has no test runner configured. Verification for each task uses `npx tsc --noEmit` (type-checking) and `npm run build:client` (bundle check), plus manual browser verification with `npm run dev` where relevant.
+
+---
+
+## File Structure
+
+Changes are confined to two files; routing in `index.ts` already handles both HTTP and WebSocket on `/dashboard`.
+
+- **`src/server.ts`** (modify): `PresenceAgent.reportToDashboard` passes `this.name`; new `@callable() getConnectionCount`; hardened `onError`.
+- **`src/dashboard.ts`** (modify): `DashboardState` shape; `updateTraffic` signature + broadcast; `onConnect`; `onStart`; `reconcile`; SSR HTML + inline WS client script.
+- **`src/index.ts`** (unchanged): `/dashboard` and `/dashboard/*` already forward to `dashboard.fetch(request)`; `Agent.fetch` handles WebSocket upgrades.
+
+---
+
+## Task 1: Change DashboardState shape and updateTraffic signature (coupled to PresenceAgent)
+
+Because `updateTraffic`'s signature and the `PresenceAgent` caller must change together, this task edits both files in one commit.
+
+**Files:**
+- Modify: `src/dashboard.ts`
+- Modify: `src/server.ts:146-156`
+
+- [ ] **Step 1: Update DashboardState type and updateTraffic in `src/dashboard.ts`**
+
+Replace the file's contents above `onRequest` (keep `onRequest` unchanged for now — it still renders the old shape and will be rewritten in Task 5):
+
+```ts
+import { Agent, callable } from "agents";
+import type { Env } from "./index";
+
+export const DASHBOARD_SINGLETON = "index";
+
+type TrafficEntry = { name: string; count: number };
+type DashboardState = {
+  traffic: Record<string, TrafficEntry>;
+  reconcileScheduleId?: string;
+};
+
+export default class DashboardServer extends Agent<Env, DashboardState> {
+  static options = {
+    hibernate: true,
+  };
+
+  initialState: DashboardState = { traffic: {} };
+
+  shouldSendProtocolMessages(): boolean {
+    return false;
+  }
+
+  @callable()
+  updateTraffic(href: string, userCount: number, name: string) {
+    const traffic = { ...this.state.traffic };
+    if (userCount <= 0) {
+      delete traffic[href];
+    } else {
+      traffic[href] = { name, count: userCount };
+    }
+    this.setState({ ...this.state, traffic });
+  }
+```
+
+Leave `onRequest` and the closing `}` as they are for now. Task 5 will rewrite the HTML renderer to read the new shape.
+
+- [ ] **Step 2: Update `reportToDashboard` in `src/server.ts:146-156` to pass `this.name`**
+
+Replace the method body:
+
+```ts
+reportToDashboard() {
+  const href = this.state?.href;
+  if (!href) return;
+  const count = [...this.getConnections()].length;
+  getAgentByName<Env, DashboardServer>(
+    this.env.DASHBOARD_SERVER,
+    DASHBOARD_SINGLETON
+  )
+    .then((stub) => stub.updateTraffic(href, count, this.name))
+    .catch((err) => console.error("Dashboard report failed:", err));
+}
+```
+
+The change is adding `, this.name` as the third argument to `stub.updateTraffic(...)`.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0 with no errors. The `onRequest` in `dashboard.ts` will produce no type error because `count` is read from `traffic[href]` after this task — wait: it still does. Read `onRequest` — line 34 reads `const traffic = this.state.traffic;` and line 38 uses `count` from `Object.entries(traffic)` where the value is now `TrafficEntry`, not `number`. This WILL produce a type error in the HTML template (`${count}`). That's fine — fix in Task 5. But tsc will fail here.
+
+If tsc errors in `onRequest`, temporarily coerce the template to keep the build green until Task 5:
+
+```ts
+const rows = sorted
+  .map(([href, entry]) => `<tr><td>${(entry as TrafficEntry).count}</td><td><a href="${href}">${href}</a></td></tr>`)
+  .join("\n");
+```
+
+And change the sort to `.sort(([, a], [, b]) => (b as TrafficEntry).count - (a as TrafficEntry).count);`.
+
+And the header:
+```ts
+<p>${sorted.length} active page${sorted.length !== 1 ? "s" : ""}, ${Object.values(traffic).reduce((sum, v) => sum + (v as TrafficEntry).count, 0)} total users</p>
+```
+
+Re-run `npx tsc --noEmit`. Expected: exits 0.
+
+- [ ] **Step 4: Build client bundle to confirm esbuild is still happy**
+
+Run: `npm run build:client`
+Expected: builds `public/cursors.js` with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dashboard.ts src/server.ts
+git commit -m "feat(dashboard): track presence agent name per traffic entry"
+```
+
+---
+
+## Task 2: Harden PresenceAgent onError to always report to dashboard
+
+**Files:**
+- Modify: `src/server.ts:207-213`
+
+- [ ] **Step 1: Replace the `onError` implementation**
+
+Replace lines 207–213 of `src/server.ts` with:
+
+```ts
+onError(connection: Connection, error: unknown): void;
+onError(error: unknown): void;
+onError(connectionOrError: Connection | unknown, error?: unknown) {
+  console.error("PresenceAgent onError", error ?? connectionOrError);
+  if (
+    connectionOrError &&
+    typeof connectionOrError === "object" &&
+    "id" in (connectionOrError as Connection)
+  ) {
+    this.leave(connectionOrError as ConnectionWithUser);
+  }
+  this.reportToDashboard();
+}
+```
+
+Two changes: (1) unconditional log at top; (2) `this.reportToDashboard()` moved out of the `if` so it runs on the global-error path too. Calling it after `leave()` (which already reports) is idempotent — the dashboard simply overwrites the count.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server.ts
+git commit -m "fix(presence): always report to dashboard on error"
+```
+
+---
+
+## Task 3: Add getConnectionCount callable to PresenceAgent
+
+**Files:**
+- Modify: `src/server.ts` (import list + add method)
+
+- [ ] **Step 1: Import `callable` in `src/server.ts:1`**
+
+Change line 1 from:
+
+```ts
+import { Agent, getAgentByName, type Connection, type ConnectionContext } from "agents";
+```
+
+to:
+
+```ts
+import { Agent, callable, getAgentByName, type Connection, type ConnectionContext } from "agents";
+```
+
+- [ ] **Step 2: Add the method inside the `PresenceAgent` class, after `reportToDashboard` (around line 156)**
+
+Insert:
+
+```ts
+  @callable()
+  getConnectionCount(): number {
+    return [...this.getConnections()].length;
+  }
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server.ts
+git commit -m "feat(presence): add getConnectionCount callable"
+```
+
+---
+
+## Task 4: Broadcast state changes and send snapshot on connect (DashboardServer)
+
+**Files:**
+- Modify: `src/dashboard.ts`
+
+- [ ] **Step 1: Import `Connection` type**
+
+Change the import line of `src/dashboard.ts` from:
+
+```ts
+import { Agent, callable } from "agents";
+```
+
+to:
+
+```ts
+import { Agent, callable, type Connection } from "agents";
+```
+
+- [ ] **Step 2: Add a private broadcast helper and an onConnect to the `DashboardServer` class**
+
+Add these methods inside the class (below `shouldSendProtocolMessages`, above `updateTraffic`):
+
+```ts
+  private broadcastState() {
+    this.broadcast(
+      JSON.stringify({ type: "state", traffic: this.state.traffic })
+    );
+  }
+
+  onConnect(connection: Connection) {
+    connection.send(
+      JSON.stringify({ type: "state", traffic: this.state.traffic })
+    );
+  }
+```
+
+- [ ] **Step 3: Call `broadcastState()` at the end of `updateTraffic`**
+
+Replace the `updateTraffic` body with:
+
+```ts
+  @callable()
+  updateTraffic(href: string, userCount: number, name: string) {
+    const traffic = { ...this.state.traffic };
+    if (userCount <= 0) {
+      delete traffic[href];
+    } else {
+      traffic[href] = { name, count: userCount };
+    }
+    this.setState({ ...this.state, traffic });
+    this.broadcastState();
+  }
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dashboard.ts
+git commit -m "feat(dashboard): broadcast state to websocket viewers"
+```
+
+---
+
+## Task 5: Rewrite dashboard HTML to new state shape + add `id="summary"`
+
+**Files:**
+- Modify: `src/dashboard.ts` (the `onRequest` method)
+
+- [ ] **Step 1: Replace the `onRequest` method**
+
+Replace the entire `onRequest` method with:
+
+```ts
+  async onRequest(req: Request) {
+    if (req.method === "GET") {
+      const traffic = this.state.traffic;
+      const sorted = Object.entries(traffic).sort(
+        ([, a], [, b]) => b.count - a.count
+      );
+
+      const rows = sorted
+        .map(
+          ([href, { count }]) =>
+            `<tr><td>${count}</td><td><a href="${href}">${href}</a></td></tr>`
+        )
+        .join("\n");
+
+      const totalUsers = Object.values(traffic).reduce(
+        (sum, v) => sum + v.count,
+        0
+      );
+
+      const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Cursor Party Dashboard</title>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #eee; }
+    th:first-child, td:first-child { width: 80px; text-align: right; }
+    a { color: #0066cc; }
+  </style>
+</head>
+<body>
+  <h1>Cursor Party Dashboard</h1>
+  <p id="summary">${sorted.length} active page${sorted.length !== 1 ? "s" : ""}, ${totalUsers} total users</p>
+  <table>
+    <thead><tr><th>Users</th><th>Page</th></tr></thead>
+    <tbody>${rows || "<tr><td colspan=\"2\">No active sessions</td></tr>"}</tbody>
+  </table>
+</body>
+</html>`;
+
+      return new Response(html, {
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+```
+
+Two changes vs. the current code: (a) values in `traffic` are destructured as `{ count }`; (b) the summary paragraph gains `id="summary"` so the inline script in Task 6 can target it.
+
+If Task 1 Step 3 added temporary `(entry as TrafficEntry)` casts, they're overwritten by this step.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0.
+
+- [ ] **Step 3: Manual check — start dev server and load the dashboard**
+
+Run: `npm run dev`
+Open: http://localhost:8787/dashboard
+
+Expected: page loads with header, the summary line, and either "No active sessions" or any existing rows rendered as `<count> | <href>`. Stop the dev server (`Ctrl+C`) before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/dashboard.ts
+git commit -m "refactor(dashboard): render new traffic shape with summary id"
+```
+
+---
+
+## Task 6: Add inline WebSocket client script to dashboard HTML
+
+**Files:**
+- Modify: `src/dashboard.ts` (the `onRequest` method — insert `<script>` before `</body>`)
+
+- [ ] **Step 1: Add an inline script that opens a WS and re-renders on state messages**
+
+In the HTML template string inside `onRequest`, insert the following `<script>` block immediately before `</body>`:
+
+```html
+<script>
+(function() {
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c];
+    });
+  }
+  function render(traffic) {
+    var entries = Object.entries(traffic).sort(function(a, b) {
+      return b[1].count - a[1].count;
+    });
+    var total = entries.reduce(function(s, e) { return s + e[1].count; }, 0);
+    var summary = document.getElementById("summary");
+    if (summary) {
+      summary.textContent = entries.length + " active page" +
+        (entries.length !== 1 ? "s" : "") + ", " + total + " total users";
+    }
+    var tbody = document.querySelector("tbody");
+    if (tbody) {
+      if (entries.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="2">No active sessions</td></tr>';
+      } else {
+        tbody.innerHTML = entries.map(function(e) {
+          var href = e[0];
+          var count = e[1].count;
+          return '<tr><td>' + count + '</td><td><a href="' +
+            escapeHtml(href) + '">' + escapeHtml(href) + '</a></td></tr>';
+        }).join("");
+      }
+    }
+  }
+  var ws;
+  function connect() {
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(proto + "//" + location.host + "/dashboard");
+    ws.onmessage = function(ev) {
+      try {
+        var msg = JSON.parse(ev.data);
+        if (msg && msg.type === "state") render(msg.traffic);
+      } catch (_) {}
+    };
+    ws.onclose = function() { setTimeout(connect, 2000); };
+    ws.onerror = function() { try { ws.close(); } catch (_) {} };
+  }
+  connect();
+})();
+</script>
+```
+
+Make sure it sits inside the template literal immediately before the `</body>` tag.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0.
+
+- [ ] **Step 3: Manual check — real-time updates**
+
+Run: `npm run dev`
+
+Open two tabs:
+1. http://localhost:8787/dashboard
+2. http://localhost:8787/ (the welcome page — this triggers a PresenceAgent connection)
+
+Expected: the dashboard tab's table adds the welcome-page row within ~1 second of tab 2 opening, with count `1`. Close tab 2 — within a second the row disappears (the PresenceAgent's `onClose` fires, reports 0, dashboard removes it, broadcast pushes the update).
+
+Open DevTools in the dashboard tab, Network → WS. Expected: one WebSocket connection open to `/dashboard`; messages flowing on traffic changes.
+
+Stop the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/dashboard.ts
+git commit -m "feat(dashboard): live websocket client with auto-reconnect"
+```
+
+---
+
+## Task 7: Daily reconciliation via scheduleEvery
+
+**Files:**
+- Modify: `src/dashboard.ts`
+
+- [ ] **Step 1: Add imports at the top of `src/dashboard.ts`**
+
+Change the imports block to:
+
+```ts
+import { Agent, callable, getAgentByName, type Connection } from "agents";
+import type { Env } from "./index";
+import type PresenceAgent from "./server";
+```
+
+- [ ] **Step 2: Add `onStart` to the `DashboardServer` class**
+
+Add this method inside the class (below `onConnect`):
+
+```ts
+  async onStart() {
+    const existingId = this.state.reconcileScheduleId;
+    if (existingId) {
+      const schedules = this.getSchedules();
+      if (schedules.some((s) => s.id === existingId)) return;
+    }
+    const schedule = await this.scheduleEvery(86400, "reconcile");
+    this.setState({ ...this.state, reconcileScheduleId: schedule.id });
+  }
+```
+
+- [ ] **Step 3: Add the `reconcile` method below `onStart`**
+
+```ts
+  async reconcile() {
+    const entries = Object.entries(this.state.traffic);
+    const next: Record<string, TrafficEntry> = {};
+    for (const [href, entry] of entries) {
+      // Skip legacy-shape entries that lack a name
+      if (
+        !entry ||
+        typeof entry !== "object" ||
+        typeof entry.name !== "string"
+      ) {
+        continue;
+      }
+      const { name } = entry;
+      try {
+        const stub = await getAgentByName<Env, PresenceAgent>(
+          this.env.PRESENCE_SERVER,
+          name
+        );
+        const count = await stub.getConnectionCount();
+        if (count > 0) next[href] = { name, count };
+      } catch (err) {
+        console.error(`Reconcile failed for ${href} (${name}):`, err);
+      }
+    }
+    this.setState({ ...this.state, traffic: next });
+    this.broadcastState();
+  }
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0.
+
+If the type-checker complains that `getSchedules()` or `scheduleEvery()` are missing from the `Agent` base class, upgrade `agents` or check the SDK version. Current lockfile is `agents@^0.11.1`, which exposes both.
+
+- [ ] **Step 5: Manual check — force a reconcile to verify it runs**
+
+Temporarily lower the interval to verify behavior (revert after). In `onStart`, change `86400` to `30` (seconds). Run:
+
+```
+npm run dev
+```
+
+Open http://localhost:8787/ in a tab and leave the dashboard open. Watch the `wrangler dev` console. Expected: every ~30s a reconcile runs (no errors, or per-entry logs if any lookup fails). Dashboard table should remain stable when the welcome page is open.
+
+Now simulate a ghost: in a PresenceAgent, entries can linger if a close doesn't fire. For a deterministic smoke test instead: open welcome page → confirm dashboard shows `1` → close welcome tab → dashboard shows empty (normal onClose path). Reconcile's value is catching cases where onClose did NOT fire; that's harder to force locally, but the method runs without error.
+
+**Revert `86400` back to the real value:**
+
+```ts
+const schedule = await this.scheduleEvery(86400, "reconcile");
+```
+
+Re-run `npx tsc --noEmit` to confirm no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dashboard.ts
+git commit -m "feat(dashboard): daily reconciliation via scheduleEvery"
+```
+
+---
+
+## Task 8: Final build + end-to-end smoke test
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Full type-check and build**
+
+Run in order:
+```
+npx tsc --noEmit
+npm run build:client
+```
+Expected: both exit 0.
+
+- [ ] **Step 2: End-to-end smoke test**
+
+Run: `npm run dev`
+
+Checklist (all should pass):
+
+1. `GET http://localhost:8787/dashboard` renders the table (empty or prior entries).
+2. Opening http://localhost:8787/ in a new tab causes the dashboard to add a row with count `1` within ~1s (via WS broadcast).
+3. Opening a second welcome-page tab updates the same row to count `2`.
+4. Closing one of the two welcome tabs drops it to `1`.
+5. Reloading the dashboard tab immediately shows the correct count (via SSR), then the WS reconnects without changing anything.
+6. Killing the dev server and restarting: dashboard comes back up; reconcile is scheduled once (check `wrangler dev` logs — no stack of "duplicate schedule" issues).
+
+Stop the dev server.
+
+- [ ] **Step 3: Confirm no orphan commits or uncommitted files**
+
+Run: `git status`
+Expected: clean working tree.
+
+---
+
+## Done
+
+At this point:
+- Dashboard viewers see live updates via WebSocket.
+- PresenceAgent reports on both error and close paths.
+- Every 24h the dashboard self-corrects by querying each tracked PresenceAgent for its real connection count.

--- a/docs/superpowers/specs/2026-04-17-dashboard-realtime-and-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-04-17-dashboard-realtime-and-reconciliation-design.md
@@ -1,0 +1,190 @@
+# Dashboard Real-Time Updates, onError Reporting, and Daily Reconciliation
+
+## Context
+
+The dashboard at `/dashboard` currently shows per-page visitor counts that are reported by each `PresenceAgent` via a singleton `DashboardServer` Durable Object. Two problems:
+
+1. The dashboard is SSR-only and only reflects traffic as of the page request; there is no live update when counts change.
+2. Many entries show "1 visitor" even when the page is idle, suggesting `onClose` isn't firing reliably on ungraceful disconnects, leaving the dashboard's `traffic` map with stale counts.
+
+## Goals
+
+- Push dashboard state changes to open viewers in real time.
+- Make presence-server error paths report current counts, not just close paths.
+- Reconcile dashboard state once per day against the ground-truth connection counts on each tracked `PresenceAgent`, dropping entries whose agent now has zero connections.
+
+## Non-goals
+
+- Rewriting the dashboard as a React/Preact app.
+- Graceful migration of existing legacy state shape (acceptable to let old entries be overwritten or cleaned up by the next reconcile).
+
+## Design
+
+### State shape
+
+`DashboardState` in `src/dashboard.ts`:
+
+```ts
+type TrafficEntry = { name: string; count: number };
+type DashboardState = {
+  traffic: Record<string, TrafficEntry>;
+  reconcileScheduleId?: string;
+};
+```
+
+- Key remains `href` (the page URL — the display identity).
+- `name` is the `PresenceAgent`'s `this.name` (the base64-encoded room-id). Needed so reconciliation can call `getAgentByName(env.PRESENCE_SERVER, name)`.
+- `reconcileScheduleId` is the id returned by `scheduleEvery`; stored so `onStart` can avoid creating duplicate schedules across hibernations or re-deploys.
+
+### PresenceAgent changes (`src/server.ts`)
+
+1. `reportToDashboard()` passes `this.name`:
+   ```ts
+   stub.updateTraffic(href, count, this.name)
+   ```
+
+2. New callable to support reconciliation:
+   ```ts
+   @callable()
+   getConnectionCount(): number {
+     return [...this.getConnections()].length;
+   }
+   ```
+
+3. `onError` hardened to always report to the dashboard:
+   ```ts
+   onError(connectionOrError: Connection | unknown, error?: unknown) {
+     console.error("PresenceAgent onError", error ?? connectionOrError);
+     if (connectionOrError && typeof connectionOrError === "object" && "id" in connectionOrError) {
+       this.leave(connectionOrError as ConnectionWithUser);
+     }
+     this.reportToDashboard();
+   }
+   ```
+   `reportToDashboard()` is idempotent (the dashboard just overwrites the count for that `href`), so calling it after `leave()` — which also reports — is harmless but guarantees a report on the global-error path too.
+
+### DashboardServer changes (`src/dashboard.ts`)
+
+1. `updateTraffic` takes `name` and broadcasts after each write:
+   ```ts
+   @callable()
+   updateTraffic(href: string, userCount: number, name: string) {
+     const traffic = { ...this.state.traffic };
+     if (userCount <= 0) delete traffic[href];
+     else traffic[href] = { name, count: userCount };
+     this.setState({ ...this.state, traffic });
+     this.broadcastState();
+   }
+
+   private broadcastState() {
+     this.broadcast(JSON.stringify({ type: "state", traffic: this.state.traffic }));
+   }
+   ```
+
+2. `onConnect` sends the current state to new viewers so the page self-corrects if the initial SSR was stale:
+   ```ts
+   onConnect(connection: Connection) {
+     connection.send(JSON.stringify({ type: "state", traffic: this.state.traffic }));
+   }
+   ```
+
+3. `onStart` schedules daily reconciliation, idempotent across restarts:
+   ```ts
+   async onStart() {
+     if (this.state.reconcileScheduleId) {
+       const exists = this.getSchedules().some(s => s.id === this.state.reconcileScheduleId);
+       if (exists) return;
+     }
+     const schedule = await this.scheduleEvery(86400, "reconcile");
+     this.setState({ ...this.state, reconcileScheduleId: schedule.id });
+   }
+   ```
+
+4. `reconcile` is the scheduled callback:
+   ```ts
+   async reconcile() {
+     const entries = Object.entries(this.state.traffic);
+     const next: Record<string, TrafficEntry> = {};
+     for (const [href, entry] of entries) {
+       // Defensively skip any legacy-shape entries that lack a name
+       if (!entry || typeof entry !== "object" || typeof entry.name !== "string") continue;
+       const { name } = entry;
+       try {
+         const stub = await getAgentByName<Env, PresenceAgent>(this.env.PRESENCE_SERVER, name);
+         const count = await stub.getConnectionCount();
+         if (count > 0) next[href] = { name, count };
+       } catch (err) {
+         console.error(`Reconcile failed for ${href} (${name}):`, err);
+       }
+     }
+     this.setState({ ...this.state, traffic: next });
+     this.broadcastState();
+   }
+   ```
+   Entries whose agent reports zero, throws, is unreachable, or is legacy-shape are dropped.
+
+### Dashboard HTML (`src/dashboard.ts` — the GET response)
+
+Keep SSR for first paint. Append a small inline `<script>` that:
+
+- Opens `ws[s]://<location.host>/dashboard`. The Agents SDK handles WebSocket upgrades inside `Agent.fetch()`, and `index.ts` already forwards `/dashboard` and `/dashboard/*` to `dashboard.fetch(request)`, so no routing changes are needed.
+- Listens for `{ type: "state", traffic }` messages and re-renders the `<tbody>` and the header count line.
+- Reconnects on close with a small backoff.
+
+Approximate client snippet:
+
+```html
+<script>
+(function() {
+  function render(traffic) {
+    const entries = Object.entries(traffic).sort(([, a], [, b]) => b.count - a.count);
+    document.querySelector("#summary").textContent =
+      `${entries.length} active page${entries.length !== 1 ? "s" : ""}, ` +
+      `${entries.reduce((sum, [, v]) => sum + v.count, 0)} total users`;
+    const tbody = document.querySelector("tbody");
+    tbody.innerHTML = entries.length
+      ? entries.map(([href, { count }]) =>
+          `<tr><td>${count}</td><td><a href="${href}">${href}</a></td></tr>`
+        ).join("")
+      : `<tr><td colspan="2">No active sessions</td></tr>`;
+  }
+  let ws;
+  function connect() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(`${proto}//${location.host}/dashboard`);
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === "state") render(msg.traffic);
+      } catch {}
+    };
+    ws.onclose = () => setTimeout(connect, 2000);
+  }
+  connect();
+})();
+</script>
+```
+
+The SSR HTML is adjusted so the header paragraph has `id="summary"` (for easy replacement) and uses the new `{name, count}` shape.
+
+### Worker routing (`src/index.ts`)
+
+No changes. `/dashboard` and `/dashboard/*` already forward to `dashboard.fetch(request)`, which handles both HTTP GET and WebSocket upgrades via the Agents SDK base class.
+
+## Error handling
+
+- Dashboard WS disconnects: client auto-reconnects after 2s.
+- Reconcile failures per entry: caught and logged; entry is dropped.
+- `onError` in `PresenceAgent`: logged; always reports current count to dashboard.
+
+## Testing
+
+Manual (no test harness exists in this repo):
+
+1. `npm run dev`, open `/dashboard` in two tabs; open the welcome page in a third tab; verify both dashboard tabs update in real time as the welcome-page tab opens/closes.
+2. `npm run build:client` to verify TypeScript compiles.
+3. Simulate a stuck ghost: open welcome page, kill the tab via forced tab-close in dev tools "Close network" + kill process, confirm presence agent still shows the connection, then trigger `reconcile` manually (temporarily lower `scheduleEvery` or call the method in a debug route) and confirm the ghost entry is removed.
+
+## Rollout
+
+One deploy. No data migration; legacy `Record<string, number>` entries will be overwritten as live agents report in, or cleared on first reconciliation run (errors drop them).

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,4 +1,4 @@
-import { Agent, callable } from "agents";
+import { Agent, callable, type Connection } from "agents";
 import type { Env } from "./index";
 
 export const DASHBOARD_SINGLETON = "index";
@@ -20,6 +20,18 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
     return false;
   }
 
+  private broadcastState() {
+    this.broadcast(
+      JSON.stringify({ type: "state", traffic: this.state.traffic })
+    );
+  }
+
+  onConnect(connection: Connection) {
+    connection.send(
+      JSON.stringify({ type: "state", traffic: this.state.traffic })
+    );
+  }
+
   @callable()
   updateTraffic(href: string, userCount: number, name: string) {
     const traffic = { ...this.state.traffic };
@@ -29,6 +41,7 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
       traffic[href] = { name, count: userCount };
     }
     this.setState({ ...this.state, traffic });
+    this.broadcastState();
   }
 
   async onRequest(req: Request) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -3,8 +3,10 @@ import type { Env } from "./index";
 
 export const DASHBOARD_SINGLETON = "index";
 
+type TrafficEntry = { name: string; count: number };
 type DashboardState = {
-  traffic: Record<string, number>;
+  traffic: Record<string, TrafficEntry>;
+  reconcileScheduleId?: string;
 };
 
 export default class DashboardServer extends Agent<Env, DashboardState> {
@@ -19,12 +21,12 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
   }
 
   @callable()
-  updateTraffic(href: string, userCount: number) {
+  updateTraffic(href: string, userCount: number, name: string) {
     const traffic = { ...this.state.traffic };
     if (userCount <= 0) {
       delete traffic[href];
     } else {
-      traffic[href] = userCount;
+      traffic[href] = { name, count: userCount };
     }
     this.setState({ ...this.state, traffic });
   }
@@ -32,10 +34,10 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
   async onRequest(req: Request) {
     if (req.method === "GET") {
       const traffic = this.state.traffic;
-      const sorted = Object.entries(traffic).sort(([, a], [, b]) => b - a);
+      const sorted = Object.entries(traffic).sort(([, a], [, b]) => b.count - a.count);
 
       const rows = sorted
-        .map(([href, count]) => `<tr><td>${count}</td><td><a href="${href}">${href}</a></td></tr>`)
+        .map(([href, { count }]) => `<tr><td>${count}</td><td><a href="${href}">${href}</a></td></tr>`)
         .join("\n");
 
       const html = `<!DOCTYPE html>
@@ -53,7 +55,7 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
 </head>
 <body>
   <h1>Cursor Party Dashboard</h1>
-  <p>${sorted.length} active page${sorted.length !== 1 ? "s" : ""}, ${Object.values(traffic).reduce((a, b) => a + b, 0)} total users</p>
+  <p>${sorted.length} active page${sorted.length !== 1 ? "s" : ""}, ${Object.values(traffic).reduce((sum, v) => sum + v.count, 0)} total users</p>
   <table>
     <thead><tr><th>Users</th><th>Page</th></tr></thead>
     <tbody>${rows || "<tr><td colspan=\"2\">No active sessions</td></tr>"}</tbody>

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -83,6 +83,53 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
     <thead><tr><th>Users</th><th>Page</th></tr></thead>
     <tbody>${rows || "<tr><td colspan=\"2\">No active sessions</td></tr>"}</tbody>
   </table>
+<script>
+(function() {
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c];
+    });
+  }
+  function render(traffic) {
+    var entries = Object.entries(traffic).sort(function(a, b) {
+      return b[1].count - a[1].count;
+    });
+    var total = entries.reduce(function(s, e) { return s + e[1].count; }, 0);
+    var summary = document.getElementById("summary");
+    if (summary) {
+      summary.textContent = entries.length + " active page" +
+        (entries.length !== 1 ? "s" : "") + ", " + total + " total users";
+    }
+    var tbody = document.querySelector("tbody");
+    if (tbody) {
+      if (entries.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="2">No active sessions</td></tr>';
+      } else {
+        tbody.innerHTML = entries.map(function(e) {
+          var href = e[0];
+          var count = e[1].count;
+          return '<tr><td>' + count + '</td><td><a href="' +
+            escapeHtml(href) + '">' + escapeHtml(href) + '</a></td></tr>';
+        }).join("");
+      }
+    }
+  }
+  var ws;
+  function connect() {
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(proto + "//" + location.host + "/dashboard");
+    ws.onmessage = function(ev) {
+      try {
+        var msg = JSON.parse(ev.data);
+        if (msg && msg.type === "state") render(msg.traffic);
+      } catch (_) {}
+    };
+    ws.onclose = function() { setTimeout(connect, 2000); };
+    ws.onerror = function() { try { ws.close(); } catch (_) {} };
+  }
+  connect();
+})();
+</script>
 </body>
 </html>`;
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -7,7 +7,6 @@ export const DASHBOARD_SINGLETON = "index";
 type TrafficEntry = { name: string; count: number };
 type DashboardState = {
   traffic: Record<string, TrafficEntry>;
-  reconcileScheduleId?: string;
 };
 
 export default class DashboardServer extends Agent<Env, DashboardState> {
@@ -34,20 +33,15 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
   }
 
   async onStart() {
-    const existingId = this.state.reconcileScheduleId;
-    if (existingId) {
-      const schedules = this.getSchedules();
-      if (schedules.some((s) => s.id === existingId)) return;
-    }
-    const schedule = await this.scheduleEvery(86400, "reconcile");
-    this.setState({ ...this.state, reconcileScheduleId: schedule.id });
+    await this.scheduleEvery(86400, "reconcile");
   }
 
   async reconcile() {
     const entries = Object.entries(this.state.traffic);
     const next: Record<string, TrafficEntry> = {};
     for (const [href, entry] of entries) {
-      // Skip legacy-shape entries that lack a name
+      // Runtime guard against legacy `Record<string, number>` entries
+      // that may still be in storage from before Task 1.
       if (
         !entry ||
         typeof entry !== "object" ||
@@ -64,6 +58,7 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
         const count = await stub.getConnectionCount();
         if (count > 0) next[href] = { name, count };
       } catch (err) {
+        // Drop on error: reconcile's purpose is to clear stale entries.
         console.error(`Reconcile failed for ${href} (${name}):`, err);
       }
     }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -121,7 +121,7 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
 (function() {
   function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, function(c) {
-      return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c];
+      return {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c];
     });
   }
   function render(traffic) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,5 +1,6 @@
-import { Agent, callable, type Connection } from "agents";
+import { Agent, callable, getAgentByName, type Connection } from "agents";
 import type { Env } from "./index";
+import type PresenceAgent from "./server";
 
 export const DASHBOARD_SINGLETON = "index";
 
@@ -30,6 +31,44 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
     connection.send(
       JSON.stringify({ type: "state", traffic: this.state.traffic })
     );
+  }
+
+  async onStart() {
+    const existingId = this.state.reconcileScheduleId;
+    if (existingId) {
+      const schedules = this.getSchedules();
+      if (schedules.some((s) => s.id === existingId)) return;
+    }
+    const schedule = await this.scheduleEvery(86400, "reconcile");
+    this.setState({ ...this.state, reconcileScheduleId: schedule.id });
+  }
+
+  async reconcile() {
+    const entries = Object.entries(this.state.traffic);
+    const next: Record<string, TrafficEntry> = {};
+    for (const [href, entry] of entries) {
+      // Skip legacy-shape entries that lack a name
+      if (
+        !entry ||
+        typeof entry !== "object" ||
+        typeof entry.name !== "string"
+      ) {
+        continue;
+      }
+      const { name } = entry;
+      try {
+        const stub = await getAgentByName<Env, PresenceAgent>(
+          this.env.PRESENCE_SERVER,
+          name
+        );
+        const count = await stub.getConnectionCount();
+        if (count > 0) next[href] = { name, count };
+      } catch (err) {
+        console.error(`Reconcile failed for ${href} (${name}):`, err);
+      }
+    }
+    this.setState({ ...this.state, traffic: next });
+    this.broadcastState();
   }
 
   @callable()

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -47,11 +47,21 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
   async onRequest(req: Request) {
     if (req.method === "GET") {
       const traffic = this.state.traffic;
-      const sorted = Object.entries(traffic).sort(([, a], [, b]) => b.count - a.count);
+      const sorted = Object.entries(traffic).sort(
+        ([, a], [, b]) => b.count - a.count
+      );
 
       const rows = sorted
-        .map(([href, { count }]) => `<tr><td>${count}</td><td><a href="${href}">${href}</a></td></tr>`)
+        .map(
+          ([href, { count }]) =>
+            `<tr><td>${count}</td><td><a href="${href}">${href}</a></td></tr>`
+        )
         .join("\n");
+
+      const totalUsers = Object.values(traffic).reduce(
+        (sum, v) => sum + v.count,
+        0
+      );
 
       const html = `<!DOCTYPE html>
 <html>
@@ -68,7 +78,7 @@ export default class DashboardServer extends Agent<Env, DashboardState> {
 </head>
 <body>
   <h1>Cursor Party Dashboard</h1>
-  <p>${sorted.length} active page${sorted.length !== 1 ? "s" : ""}, ${Object.values(traffic).reduce((sum, v) => sum + v.count, 0)} total users</p>
+  <p id="summary">${sorted.length} active page${sorted.length !== 1 ? "s" : ""}, ${totalUsers} total users</p>
   <table>
     <thead><tr><th>Users</th><th>Page</th></tr></thead>
     <tbody>${rows || "<tr><td colspan=\"2\">No active sessions</td></tr>"}</tbody>

--- a/src/server.ts
+++ b/src/server.ts
@@ -151,7 +151,7 @@ export default class PresenceAgent extends Agent<Env, { href?: string }> {
       this.env.DASHBOARD_SERVER,
       DASHBOARD_SINGLETON
     )
-      .then((stub) => stub.updateTraffic(href, count))
+      .then((stub) => stub.updateTraffic(href, count, this.name))
       .catch((err) => console.error("Dashboard report failed:", err));
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { Agent, getAgentByName, type Connection, type ConnectionContext } from "agents";
+import { Agent, callable, getAgentByName, type Connection, type ConnectionContext } from "agents";
 import type { Env } from "./index";
 import type {
   Metadata,
@@ -153,6 +153,11 @@ export default class PresenceAgent extends Agent<Env, { href?: string }> {
     )
       .then((stub) => stub.updateTraffic(href, count, this.name))
       .catch((err) => console.error("Dashboard report failed:", err));
+  }
+
+  @callable()
+  getConnectionCount(): number {
+    return [...this.getConnections()].length;
   }
 
   onMessage(

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,9 +207,15 @@ export default class PresenceAgent extends Agent<Env, { href?: string }> {
   onError(connection: Connection, error: unknown): void;
   onError(error: unknown): void;
   onError(connectionOrError: Connection | unknown, error?: unknown) {
-    if (connectionOrError instanceof Object && "id" in (connectionOrError as Connection)) {
+    console.error("PresenceAgent onError", error ?? connectionOrError);
+    if (
+      connectionOrError &&
+      typeof connectionOrError === "object" &&
+      "id" in (connectionOrError as Connection)
+    ) {
       this.leave(connectionOrError as ConnectionWithUser);
     }
+    this.reportToDashboard();
   }
 
   async scheduleBroadcast() {


### PR DESCRIPTION
## Summary

- Dashboard updates push in real time over WebSocket — `updateTraffic` now broadcasts state to all connected viewers, and `onConnect` sends the current snapshot
- `PresenceAgent.onError` always reports to the dashboard (both per-connection and global-error paths), closing a gap where stale counts could linger
- `DashboardServer.onStart` schedules `reconcile` daily via `scheduleEvery(86400, "reconcile")` (SDK-idempotent); `reconcile` queries each tracked PresenceAgent's real connection count and drops zero/failed entries

See `docs/superpowers/specs/2026-04-17-dashboard-realtime-and-reconciliation-design.md` and `docs/superpowers/plans/2026-04-17-dashboard-realtime-and-reconciliation.md`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build:client` succeeds
- [x] Dashboard HTML renders with `id="summary"` and inline WS client script (verified via curl)
- [x] Rendered inline JS is syntactically valid (verified with `node --check`)
- [ ] Browser: open `/dashboard` + welcome page in separate tabs; confirm dashboard row appears on connect and disappears on close within ~1s
- [ ] Browser: dev tools Network → WS shows one open connection per dashboard tab; messages flow on traffic changes
- [ ] Verify no JS console errors on dashboard page

🤖 Generated with [Claude Code](https://claude.com/claude-code)